### PR TITLE
Add custom group and record access rules for non-admin users

### DIFF
--- a/alnas_docx/__manifest__.py
+++ b/alnas_docx/__manifest__.py
@@ -25,8 +25,9 @@
     'depends': ['base', 'mail'],
 
     'data': [
+        'security/security.xml',
         'security/ir.model.access.csv',
-        
+
         'data/ir_config_data.xml',
         
         'views/docx_report_config_view.xml',

--- a/alnas_docx/security/ir.model.access.csv
+++ b/alnas_docx/security/ir.model.access.csv
@@ -1,2 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-alnas_docx.access_docx_report_config,access_docx_report_config,alnas_docx.model_docx_report_config,base.group_user,1,1,1,1
+access_docx_report_config_report_editors,access_docx_report_config_report_editors,alnas_docx.model_docx_report_config,group_docx_report_editors,1,1,1,1
+access_ir_model_fields_report_editors,access_ir_model_fields_report_editors,base.model_ir_model_fields,group_docx_report_editors,1,0,0,0
+accesss_ir_model_report_editors,accesss_ir_model_report_editors,base.model_ir_model,group_docx_report_editors,1,0,0,0

--- a/alnas_docx/security/security.xml
+++ b/alnas_docx/security/security.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+
+        <record id="res_groups_privilege_docx_reporting" model="res.groups.privilege">
+            <field name="name">Docx Reports</field>
+            <field name="category_id" ref="base.module_category_master_data"/>
+            <field name="sequence">20</field>
+        </record>
+
+        <!-- Report Editor Group -->
+        <record id="group_docx_report_editors" model="res.groups">
+            <field name="name">Report Editor</field>
+            <field name="privilege_id" ref="res_groups_privilege_docx_reporting"/>
+            <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This PR adds a custom group and the corresponding record access rules that allows a user to edit .docx reports.

Previously a regular user (base.group_user) could not use the module unless he had been given access to read ir.model and ir.model.fields records either manually or through some other group.

It was also not possible to restrict some users from accessing the report creation screen, in case one wished to only have a specific group of employees to edit reports.

Thank you for the module btw !