### PR TITLE
Add format_datetime helper for DOCX templates (timezone + strftime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To call and write the field name, use the following format: `{{docs.field_name}}
 
 - `{{spelled_out(docs.numeric_field)}}`: Spell out numbers
 - `{{formatdate(docs.date_field)}}`: Format dates
+- `{{format_datetime(docs.datetime_field)}}`: Format datetime fields with correct tz, defaults to UTC. Example: {{ format_datetime(docs.your_datetime_field, 'Europe/Berlin', '%d.%m.%Y %H:%M') }}
 - `{{parsehtml(docs.html_field)}}` : Render HTML content as plain text
 - `{{p html2docx(docs.html_field)}}`: Render HTML as subdocument
 - `{{convert_currency(docs.monetary_field, docs.currency_id)}}`: Show monetary field

--- a/alnas_docx/README.md
+++ b/alnas_docx/README.md
@@ -27,6 +27,7 @@ To call and write the field name, use the following format: `{{docs.field_name}}
 
 - `{{spelled_out(docs.numeric_field)}}`: Spell out numbers
 - `{{formatdate(docs.date_field)}}`: Format dates
+- `{{format_datetime(docs.datetime_field)}}`: Format datetime fields with correct tz, defaults to UTC. Example: {{ format_datetime(docs.your_datetime_field, 'Europe/Berlin', '%d.%m.%Y %H:%M') }}
 - `{{parsehtml(docs.html_field)}}` : Render HTML content as plain text
 - `{{p html2docx(docs.html_field)}}`: Render HTML as subdocument
 - `{{convert_currency(docs.monetary_field, docs.currency_id)}}`: Show monetary field

--- a/alnas_docx/models/ir_actions_report.py
+++ b/alnas_docx/models/ir_actions_report.py
@@ -54,6 +54,7 @@ class IrActionsReport(models.Model):
             "spelled_out": misc_tools.spelled_out,
             "parsehtml": misc_tools.parse_html,
             "formatdate": misc_tools.formatdate,
+            "format_datetime": misc_tools.format_datetime,
             "convert_currency": misc_tools.convert_currency,
             "formatabs": misc_tools.format_abs,
             "rich_text": misc_tools.rich_text,

--- a/alnas_docx/tools/misc.py
+++ b/alnas_docx/tools/misc.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 from base64 import b64decode
-from datetime import datetime
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
 from docx import Document
 from docx.shared import Mm
 from docxtpl import InlineImage, RichText
@@ -83,6 +84,27 @@ def parse_html(html):
 
 def formatdate(date_required=datetime.today(), format="full", lang="id_ID", **kwargs):
     return format_date(date_required, format=format, locale=lang, **kwargs)
+
+def format_datetime(dt, tz=None, format="%Y-%m-%d %H:%M:%S", **kwargs):
+    if not dt:
+        return ""
+    if tz is None:
+        tz_target = ZoneInfo("UTC")
+    elif isinstance(tz, ZoneInfo):
+        tz_target = tz
+    else:
+        try:
+            tz_target = ZoneInfo(str(tz))
+        except Exception:
+            tz_target = ZoneInfo("UTC")
+    if isinstance(dt, date) and not isinstance(dt, datetime):
+        return dt.strftime(format)
+    if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+        local_dt = dt.astimezone(tz_target)
+        return local_dt.strftime(format)
+    return str(dt)
 
 def spelled_out(number, lang="id_ID", to="cardinal", **kwargs):
     return num2words(number, lang=lang, to=to, **kwargs)


### PR DESCRIPTION
**Summary**
Expose a format_datetime helper in the DOCX render context so templates can show datetime values in a chosen timezone and with a custom strftime format (e.g. %d.%m.%Y %H:%M). Naive datetimes are treated as UTC; plain date values are formatted without timezone conversion.

**Changes**
Add `format_datetime` in alnas_docx/tools/misc.py.
Register it in `_get_rendering_context_docx` as `format_datetime` (alongside existing formatdate / Babel helpers).

**Usage (templates)**
Example: `{{ format_datetime(docs.some_datetime_field, tz='Europe/Berlin', format='%d.%m.%Y %H:%M') }}`

**Note**
This complements formatdate (Babel locale formatting); it does not replace it—use this when you need explicit timezone conversion and strftime-style patterns.