### PR TITLE
Custom report name

### DIFF
--- a/alnas_docx/models/docx_report_config.py
+++ b/alnas_docx/models/docx_report_config.py
@@ -75,7 +75,13 @@ class DocxReportConfig(models.Model):
     print_report_name = fields.Char(
         string="Print Report Name",
         compute="_compute_print_report_name",
+        store=True,
         help="Filename generated for the report",
+    )
+    print_report_name_override = fields.Boolean(
+        string="Override Print Report Name",
+        default=False,
+        help="This lets you manually edit the report name. Old and new python string formatting is supported. Use with caution!",
     )
     autoescape = fields.Boolean(
         string="Autoescape",
@@ -83,9 +89,11 @@ class DocxReportConfig(models.Model):
         help="Enable autoescape for special character like <, > and &.",
     )
 
-    @api.depends("model_id", "field_id", "prefix")
+    @api.depends("model_id", "field_id", "prefix", "print_report_name_override")
     def _compute_print_report_name(self):
         for rec in self:
+            if rec.print_report_name_override:
+                continue
             if rec.prefix:
                 rec.print_report_name = f"'{rec.prefix} %s' % object.{rec.field_id.name} if object.{rec.field_id.name} else ''"
             else:

--- a/alnas_docx/views/docx_report_config_view.xml
+++ b/alnas_docx/views/docx_report_config_view.xml
@@ -34,7 +34,8 @@
                         <field name="report_docx_template" filename="report_docx_template_filename" readonly="state != 'draft'"/>
                         <field name="report_docx_template_filename" invisible="1" readonly="state != 'draft'"/>
                         <field name="docx_merge_mode" readonly="state != 'draft'"/>
-                        <field name="print_report_name"/>
+                        <field name="print_report_name" readonly="state != 'draft' or not print_report_name_override" placeholder="f'Report {object.display_name}'" required="True" />
+                        <field name="print_report_name_override" readonly="state != 'draft'" string="Custom Report Name" />
                         <field name="autoescape" readonly="state != 'draft'"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
**Summary**
This change adds a custom report name flow for DOCX reports so users can override the default filename expression directly from the report config form.
The feature keeps the existing auto-generated name behavior by default, but allows manual naming when override is enabled, with support for both old % formatting and modern Python/f-string style expressions.

**Changes**
print_report_name_override / print_report_name in alnas_docx/models/docx_report_config.py: keeps computed default naming when override is off, and preserves user-entered custom expressions when override is on.
Made filename expression field editable only when override is enabled and record is still draft.

**Example (custom filename expression)**
`f'Invoice - {object.name}'`
`'%s - %s' % (object.partner_id.name, object.name)`

**Motivation**
Lets users control output filenames per report configuration without code changes, while keeping a safe default naming pattern for non-customized reports. This reduces manual renaming and makes generated files easier to identify in user workflows.