### PR TITLE
Fix for empty print names

### DIFF
--- a/alnas_docx/models/docx_report_config.py
+++ b/alnas_docx/models/docx_report_config.py
@@ -89,6 +89,17 @@ class DocxReportConfig(models.Model):
         help="Enable autoescape for special character like <, > and &.",
     )
 
+    def init(self):
+        records = self.search([
+            ("print_report_name_override", "=", False),
+            "|",
+            ("print_report_name", "=", False),
+            ("print_report_name", "=", ""),
+        ])
+        if records:
+            records._compute_print_report_name()
+            self.flush_model(["print_report_name"])
+
     @api.depends("model_id", "field_id", "prefix", "print_report_name_override")
     def _compute_print_report_name(self):
         for rec in self:


### PR DESCRIPTION
In #11 I created an issue where existing reports have empty names because the field was computed and not stored before the custom report name feature was added.

This PR adds an init() method in `docx.report.config` to generate the names for those reports. Maybe there is a better way to do that (with a migration script for example) but I think for the migration it is fine.